### PR TITLE
fix | added condition account must have value | de

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -366,7 +366,7 @@ export const Header = () => {
 			dispatch({ type: VerificationEnum.ACCOUNT, payload: '' });
 		}
 
-		if (account && storage && storage?.account !== account) {
+		if (account && storage?.account && storage?.account !== account) {
 			addToast(
 				'Please login to the account that has already passed KYC or connect wallet again',
 				'warning'


### PR DESCRIPTION
There was a false positive addToast execution in the `header.tsx line 370`
It happens when on line 369, in the if statement `storage?.account` value is `undefined` and it does not equal to `account` value. This comparison should be executed with the two account addresses otherwise it's going to be a false positive🤓